### PR TITLE
Use SSLv23_method to negotiate best mutually supported TLS version

### DIFF
--- a/nagios-sip-plugin.rb
+++ b/nagios-sip-plugin.rb
@@ -117,7 +117,7 @@ module NagiosSipPlugin
             else
               ssl_context.verify_mode = OpenSSL::SSL::VERIFY_NONE
             end
-            ssl_context.ssl_version = :TLSv1
+            ssl_context.ssl_version = :SSLv23
 
             @io = OpenSSL::SSL::SSLSocket.new(sock, ssl_context)
             @io.sync_close = true


### PR DESCRIPTION
More details available in the OpenSSL API.

https://www.openssl.org/docs/man1.1.0/man3/SSLv23_method.html